### PR TITLE
Per-node time information

### DIFF
--- a/server/static/details.html
+++ b/server/static/details.html
@@ -21,13 +21,21 @@
     <header>
 
         <div class="times">
-            <span data-toggle="tooltip" title="Total time spent">
+            <span data-toggle="tooltip" title="Cumulative time spent in this function here">
                 <i class="fa fa-clock-o"></i>
+                <strong>{{ (node_total_time * 100).toFixed(2) }}%</strong>
+            </span>
+            <span data-toggle="tooltip" title="Cumulative time spent in this function everywhere">
+                /
                 <strong>{{ (total_time * 100).toFixed(2) }}%</strong>
             </span>
 
-            <span data-toggle="tooltip" title="Time spent in this function">
+            <span data-toggle="tooltip" title="Time spent in this function here">
                 <i class="fa fa-arrow-down"></i>
+                <strong>{{ (node_self_time * 100).toFixed(2) }}%</strong>
+            </span>
+            <span data-toggle="tooltip" title="Time spent in this function everywhere">
+                /
                 <strong>{{ (self_time * 100).toFixed(2) }}%</strong>
             </span>
         </div>

--- a/server/static/main.js
+++ b/server/static/main.js
@@ -281,6 +281,8 @@ app.controller('details', function ($scope, $http, $routeParams, $timeout,
         $scope.root = d.root;
         $scope.total_time = stats.allStats[d.root.addr].total / stats.nodes.total;
         $scope.self_time = stats.allStats[d.root.addr].self / stats.nodes.total;
+        $scope.node_total_time = d.root.total / stats.nodes.total;
+        $scope.node_self_time = d.root.self / stats.nodes.total;
         $scope.paths = d.paths;
 
         $timeout(function () {


### PR DESCRIPTION
This branch splits the time information (cumulative and function-only) into "node / total" so that we can see how the times are split between calls to a function from multiple places.

For example, the `split` entries in http://vmprof.baroquesoftware.com/#/e897cb616042264707466e14d64b59a5 would show ":clock9: 54.29% / 100.00% :arrow_down: 5.99% / 11.14%" and ":clock9: 45.71% / 100.00% :arrow_down: 5.15% / 11.14%" instead of both showing ":clock9: 100.00% :arrow_down: 11.67%". (The differences in the function-only time due to copying numbers from two different runs pointing at different servers.)