### PR TITLE
Fix a python 2 incompability with the import.

### DIFF
--- a/vmprofile/views.py
+++ b/vmprofile/views.py
@@ -3,7 +3,10 @@ import io
 import json
 import hashlib
 import datetime
-from urllib import parse
+try:
+    from urlparse import urlparse as parse
+except ImportError:
+    from urllib import parse
 
 from django.contrib import auth
 from django.http import HttpResponse


### PR DESCRIPTION
This allows vmprof-server to be run in a python 2 environment.