### PR TITLE
Run vmprof-server in a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
 #FROM alpine:3.7
+# Using pre-built Pandas image since building Pandas from sources is too slow
 FROM amancevice/pandas:0.22.0-python3-alpine
 
 EXPOSE 8000
-
-RUN apk add --no-cache python3 \
-        py3-yaml py3-cryptography py3-six py3-requests sqlite py-pysqlite libunwind-dev uwsgi-python3 \
-        gcc g++ musl-dev zlib-dev python3-dev git
-
-COPY . /usr/src/vmprof-server
-
-#RUN pip3 install raven==5.3.1
-RUN pip3 install -r /usr/src/vmprof-server/requirements/docker.txt
-
-RUN pip3 install -e git://github.com/vmprof/vmprof-python.git#egg=vmprof
-
-#RUN cp -pr /usr/src/vmprof-server/vmprof3/src/vmprof /usr/lib/python3.6/site-packages/
-
 VOLUME /data
 ENV SQLITE_DB=/data/vmprof.db
 
+RUN apk add --no-cache python3 \
+        py3-yaml py3-cryptography py3-six py3-requests sqlite py-pysqlite libunwind-dev uwsgi-python3 \
+        gcc g++ musl-dev postgresql-dev python3-dev git
+
+COPY requirements /usr/src/requirements
+
+RUN pip3 install -r /usr/src/requirements/testing.txt
+RUN pip3 install -e git://github.com/vmprof/vmprof-python.git#egg=vmprof
+
+COPY . /usr/src/vmprof-server
 WORKDIR /usr/src/vmprof-server
-#RUN pip3 install vmprof3/src/vmprof
-#RUN python3 manage.py migrate
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000", "-v", "3"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+#FROM alpine:3.7
+FROM amancevice/pandas:0.22.0-python3-alpine
+
+EXPOSE 8000
+
+RUN apk add --no-cache python3 \
+        py3-yaml py3-cryptography py3-six py3-requests sqlite py-pysqlite libunwind-dev uwsgi-python3 \
+        gcc g++ musl-dev zlib-dev python3-dev git
+
+COPY . /usr/src/vmprof-server
+
+#RUN pip3 install raven==5.3.1
+RUN pip3 install -r /usr/src/vmprof-server/requirements/docker.txt
+
+RUN pip3 install -e git://github.com/vmprof/vmprof-python.git#egg=vmprof
+
+#RUN cp -pr /usr/src/vmprof-server/vmprof3/src/vmprof /usr/lib/python3.6/site-packages/
+
+VOLUME /data
+ENV SQLITE_DB=/data/vmprof.db
+
+WORKDIR /usr/src/vmprof-server
+#RUN pip3 install vmprof3/src/vmprof
+#RUN python3 manage.py migrate
+
+CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000", "-v", "3"]
+

--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ For new feature requests open a new branch or fork the repository. We use contin
 provided by travis. Before you commit run tests using py.test:
 
 	py.test .
+
+
+## Docker
+
+Build docker image:
+
+	docker docker build -t vmprof-server .
+
+Run the server inside docker container:
+
+	mkdir -p $PWD/data
+	docker run --rm -ti -p 8000:8000 -v $PWD/data:/data vmprof-server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/sh -x
 
 if [ -n $SQLITE_DB -a ! -e $SQLITE_DB ]; then
-    RUN python3 manage.py migrate
+    python3 manage.py migrate
 fi
 
+exec $@

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -n $SQLITE_DB -a ! -e $SQLITE_DB ]; then
+    RUN python3 manage.py migrate
+fi
+

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,2 +1,2 @@
 -r development.txt
-psycopg2==2.6.1
+psycopg2==2.7.4

--- a/webapp/settings/__init__.py
+++ b/webapp/settings/__init__.py
@@ -59,7 +59,7 @@ WSGI_APPLICATION = 'webapp.wsgi.app'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'sqlite3.db',
+        'NAME': os.environ.get('SQLITE_DB', 'sqlite3.db'),
     }
 }
 


### PR DESCRIPTION
Adds scripts for building a docker image for vmprof-server.

Had to upgrade psycopg2 to 2.7.4, since 2.6.x refuses to build with Postgres 10.x.

Future plans:

1. Run the server as a normal user, make root fs read-only
2. Add instructions to run tests inside a docker container
3. Create a repo at hub.docker.com
4. Use builder pattern to reduce image size
