### PR TITLE
Add psutil to requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ twisted
 django-appconf
 pandas
 msgpack-python
+psutil


### PR DESCRIPTION
Since 569306e362616da3488a31417c0f58d64e30d7b0, psutil is a dependency, so it needs to be in the requirements/*.txt. This should fix CI.