### PR TITLE
Fixing Dockerfile build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV SQLITE_DB=/data/vmprof.db
 
 RUN apk add --no-cache python3 \
         py3-yaml py3-cryptography py3-six py3-requests sqlite py-pysqlite libunwind-dev uwsgi-python3 \
-        gcc g++ musl-dev postgresql-dev python3-dev git
+        gcc g++ musl-dev postgresql-dev python3-dev git linux-headers
 
 COPY requirements /usr/src/requirements
 


### PR DESCRIPTION
Due to missing header files the previous Dockerfile could not be built.

The problem occurred when the dependency psutil was being built
resulting in the following error:

No such file or directory #include <linux/types.h>

By adding the apk package linux-headers this problem could be resolved
and the Dockerfile is again buildable.